### PR TITLE
[Feature] card info, 에러 처리 logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/potato/balbambalbam/MyCommandLineRunner.java
+++ b/src/main/java/com/potato/balbambalbam/MyCommandLineRunner.java
@@ -12,16 +12,11 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class MyCommandLineRunner implements CommandLineRunner {
 
     private final UpdatePhonemeService updatePhonemeService;
     @Override
     public void run(String... args) throws Exception {
-        updateCardPhoneme();
-    }
-
-    protected void updateCardPhoneme(){
         updatePhonemeService.updateCardPhonemeColumn();
     }
 }

--- a/src/main/java/com/potato/balbambalbam/MyCommandLineRunner.java
+++ b/src/main/java/com/potato/balbambalbam/MyCommandLineRunner.java
@@ -1,6 +1,6 @@
 package com.potato.balbambalbam;
 
-import com.potato.balbambalbam.main.service.UpdatePhonemeService;
+import com.potato.balbambalbam.main.cardList.service.UpdatePhonemeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;

--- a/src/main/java/com/potato/balbambalbam/entity/CardBookmark.java
+++ b/src/main/java/com/potato/balbambalbam/entity/CardBookmark.java
@@ -6,8 +6,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import lombok.Getter;
 
-import java.io.Serializable;
-
 @Entity(name = "card_bookmark")
 @Getter
 @IdClass(CardBookmarkId.class)

--- a/src/main/java/com/potato/balbambalbam/entity/CardWeakSound.java
+++ b/src/main/java/com/potato/balbambalbam/entity/CardWeakSound.java
@@ -6,8 +6,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import lombok.Getter;
 
-import java.io.Serializable;
-
 @Entity(name = "card_weaksound")
 @Getter
 @IdClass(CardWeakSoundId.class)

--- a/src/main/java/com/potato/balbambalbam/main/MainExceptionResolverController.java
+++ b/src/main/java/com/potato/balbambalbam/main/MainExceptionResolverController.java
@@ -1,5 +1,6 @@
-package com.potato.balbambalbam.main.cardList.dto;
+package com.potato.balbambalbam.main;
 
+import com.potato.balbambalbam.main.cardList.dto.ExceptionDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class MainExceptionResolverController {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ExceptionDto> illegalArgumentExceptionHandler(IllegalArgumentException ex){
+        ExceptionDto exceptionDto = new ExceptionDto("IllegalArgumentException", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionDto);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ExceptionDto> runtimeExceptionHandler(RuntimeException ex){
         ExceptionDto exceptionDto = new ExceptionDto("IllegalArgumentException", ex.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionDto);
     }

--- a/src/main/java/com/potato/balbambalbam/main/MainExceptionResolverController.java
+++ b/src/main/java/com/potato/balbambalbam/main/MainExceptionResolverController.java
@@ -1,6 +1,10 @@
 package com.potato.balbambalbam.main;
 
+import com.potato.balbambalbam.main.cardInfo.exception.AiConnectionException;
+import com.potato.balbambalbam.main.cardInfo.exception.UserNotFoundException;
 import com.potato.balbambalbam.main.cardList.dto.ExceptionDto;
+import com.potato.balbambalbam.main.cardList.exception.CardNotFoundException;
+import com.potato.balbambalbam.main.cardList.exception.CategoryNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,15 +13,34 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 public class MainExceptionResolverController {
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ExceptionDto> illegalArgumentExceptionHandler(IllegalArgumentException ex){
-        ExceptionDto exceptionDto = new ExceptionDto("IllegalArgumentException", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionDto);
+
+    @ExceptionHandler({AiConnectionException.class, UserNotFoundException.class, CategoryNotFoundException.class, CardNotFoundException.class})
+    public ResponseEntity<ExceptionDto> aiConnectionException(Exception ex){
+        return exceptionHandler(ex, HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ExceptionDto> runtimeExceptionHandler(RuntimeException ex){
-        ExceptionDto exceptionDto = new ExceptionDto("IllegalArgumentException", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionDto);
+    @ExceptionHandler({IllegalArgumentException.class, RuntimeException.class})
+    public ResponseEntity<ExceptionDto> illegalArgumentExceptionHandler(IllegalArgumentException ex){
+        return exceptionHandler(ex, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 에러 메서드 처리
+     * @param ex
+     * @param httpStatus
+     * @return
+     */
+    protected ResponseEntity<ExceptionDto> exceptionHandler(Exception ex, HttpStatus httpStatus){
+        String className = extractClassName(ex.getClass().toString());
+        String exMessage = ex.getMessage();
+
+        log.info("[ERROR] ["+ className + "]:" + exMessage);
+
+        return ResponseEntity.status(httpStatus).body(new ExceptionDto(className, exMessage));
+    }
+
+    protected String extractClassName(String fullClassName){
+        String[] classNameParts = fullClassName.split("\\.");
+        return classNameParts[classNameParts.length - 1];
     }
 }

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/controller/CardInfoController.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/controller/CardInfoController.java
@@ -2,8 +2,13 @@ package com.potato.balbambalbam.main.cardInfo.controller;
 
 import com.potato.balbambalbam.main.cardInfo.dto.CardInfoResponseDto;
 import com.potato.balbambalbam.main.cardInfo.service.CardInfoService;
+import com.potato.balbambalbam.main.cardList.dto.ExceptionDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -16,6 +21,7 @@ import java.nio.charset.Charset;
 
 @Controller
 @RequiredArgsConstructor
+@Tag(name = "CardInfo", description = "CardInfo API")
 public class CardInfoController {
     //TODO : user 동적으로 할당
     public static final long TEMPORARY_USER_ID = 1L;
@@ -23,7 +29,13 @@ public class CardInfoController {
 
     @GetMapping("/cards/{cardId}")
     @Operation(summary = "card info 제공", description = "카드 id, 카드 text, 발음 text, 맞춤 음성 제공")
-    @ApiResponses()
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "OK : 카드 정보, 음성 제공 성공"),
+                    @ApiResponse(responseCode = "400", description = "ERROR : 카드 또는 회원 조회 실패", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
+                    @ApiResponse(responseCode = "404", description = "ERROR : 카드 음성 생성 실패",  content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
+            }
+    )
     public ResponseEntity<CardInfoResponseDto> postCardInfo(@PathVariable("cardId") Long cardId) {
         CardInfoResponseDto cardInfoResponseDto = cardInfoService.getCardInfo(cardId, TEMPORARY_USER_ID);
 

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/controller/CardInfoController.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/controller/CardInfoController.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-import java.io.IOException;
 import java.nio.charset.Charset;
 
 @Controller
@@ -22,7 +21,7 @@ public class CardInfoController {
     public static final long TEMPORARY_USER_ID = 1L;
     private final CardInfoService cardInfoService;
 
-    @GetMapping("cards/{cardId}")
+    @GetMapping("/cards/{cardId}")
     @Operation(summary = "card info 제공", description = "카드 id, 카드 text, 발음 text, 맞춤 음성 제공")
     @ApiResponses()
     public ResponseEntity<CardInfoResponseDto> postCardInfo(@PathVariable("cardId") Long cardId) {

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/controller/CardInfoController.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/controller/CardInfoController.java
@@ -1,20 +1,37 @@
 package com.potato.balbambalbam.main.cardInfo.controller;
 
+import com.potato.balbambalbam.main.cardInfo.dto.CardInfoResponseDto;
+import com.potato.balbambalbam.main.cardInfo.service.CardInfoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+
 @Controller
+@RequiredArgsConstructor
 public class CardInfoController {
+    //TODO : user 동적으로 할당
+    public static final long TEMPORARY_USER_ID = 1L;
+    private final CardInfoService cardInfoService;
 
     @GetMapping("cards/{cardId}")
     @Operation(summary = "card info 제공", description = "카드 id, 카드 text, 발음 text, 맞춤 음성 제공")
     @ApiResponses()
-    public ResponseEntity postCardInfo(@PathVariable("cardId") Long cardId){
+    public ResponseEntity<CardInfoResponseDto> postCardInfo(@PathVariable("cardId") Long cardId) {
+        CardInfoResponseDto cardInfoResponseDto = cardInfoService.getCardInfo(cardId, TEMPORARY_USER_ID);
 
-        return null;
+        HttpHeaders headers = new HttpHeaders();
+        MediaType mediaType = new MediaType("application", "json", Charset.forName("UTF-8"));
+        headers.setContentType(mediaType);
+
+        return ResponseEntity.ok().headers(headers).body(cardInfoResponseDto);
     }
 }

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/controller/CardInfoController.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/controller/CardInfoController.java
@@ -1,0 +1,20 @@
+package com.potato.balbambalbam.main.cardInfo.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+public class CardInfoController {
+
+    @GetMapping("cards/{cardId}")
+    @Operation(summary = "card info 제공", description = "카드 id, 카드 text, 발음 text, 맞춤 음성 제공")
+    @ApiResponses()
+    public ResponseEntity postCardInfo(@PathVariable("cardId") Long cardId){
+
+        return null;
+    }
+}

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/dto/CardInfoResponseDto.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/dto/CardInfoResponseDto.java
@@ -1,8 +1,11 @@
 package com.potato.balbambalbam.main.cardInfo.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class CardInfoResponseDto {

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/dto/CardInfoResponseDto.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/dto/CardInfoResponseDto.java
@@ -12,5 +12,6 @@ public class CardInfoResponseDto {
     private Long id;
     private String text;
     private String pronunciation;
+    private boolean isBookmark;
     private String ttsVoice;
 }

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/dto/CardInfoResponseDto.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/dto/CardInfoResponseDto.java
@@ -1,0 +1,13 @@
+package com.potato.balbambalbam.main.cardInfo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public class CardInfoResponseDto {
+    private Long id;
+    private String text;
+    private String pronunciation;
+    private String ttsVoice;
+}

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/dto/VoiceRequestDto.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/dto/VoiceRequestDto.java
@@ -1,13 +1,14 @@
 package com.potato.balbambalbam.main.cardInfo.dto;
 
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
-@Getter
+@Getter @Setter
 @ToString
 public class VoiceRequestDto {
     public Integer age;
-    public Integer gender;
+    public Integer gender;  //0 : 여자 , 1 : 남자
 
     public VoiceRequestDto(Integer age, Integer gender) {
         this.age = age;

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/dto/VoiceRequestDto.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/dto/VoiceRequestDto.java
@@ -1,0 +1,16 @@
+package com.potato.balbambalbam.main.cardInfo.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class VoiceRequestDto {
+    public Integer age;
+    public Integer gender;
+
+    public VoiceRequestDto(Integer age, Integer gender) {
+        this.age = age;
+        this.gender = gender;
+    }
+}

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/exception/AiConnectionException.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/exception/AiConnectionException.java
@@ -1,9 +1,5 @@
 package com.potato.balbambalbam.main.cardInfo.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "통신 가능 최대 시간 초과.")
 public class AiConnectionException extends RuntimeException {
     public AiConnectionException(String message) {
         super(message);

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/exception/AiConnectionException.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/exception/AiConnectionException.java
@@ -1,0 +1,11 @@
+package com.potato.balbambalbam.main.cardInfo.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "통신 가능 최대 시간 초과.")
+public class AiConnectionException extends RuntimeException {
+    public AiConnectionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/exception/UserNotFoundException.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/exception/UserNotFoundException.java
@@ -1,9 +1,5 @@
 package com.potato.balbambalbam.main.cardInfo.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "잘못된 요청입니다.")
 public class UserNotFoundException extends RuntimeException{
     public UserNotFoundException(String message) {
         super(message);

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/exception/UserNotFoundException.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/exception/UserNotFoundException.java
@@ -3,7 +3,7 @@ package com.potato.balbambalbam.main.cardInfo.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "User Not Found")
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "잘못된 요청입니다.")
 public class UserNotFoundException extends RuntimeException{
     public UserNotFoundException(String message) {
         super(message);

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/exception/UserNotFoundException.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/exception/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.potato.balbambalbam.main.cardInfo.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "User Not Found")
+public class UserNotFoundException extends RuntimeException{
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/service/AiCardInfoService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/service/AiCardInfoService.java
@@ -17,13 +17,13 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class AiCardInfoService {
     public static final String TEMPORARY_URI = "/아직안정해짐";
     WebClient webClient = WebClient.builder().build();
-    public MultipartFile getTtsVoice(VoiceRequestDto voiceRequestDto) {
-        MultipartFile wavFile = webClient.post()
+    public String getTtsVoice(VoiceRequestDto voiceRequestDto) {
+        String wavFile = webClient.post()
                 .uri(TEMPORARY_URI)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(voiceRequestDto, VoiceRequestDto.class)
                 .retrieve()//요청
-                .bodyToMono(MultipartFile.class)
+                .bodyToMono(String.class)
                 .block();
 
         return wavFile;

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/service/AiCardInfoService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/service/AiCardInfoService.java
@@ -1,0 +1,20 @@
+package com.potato.balbambalbam.main.cardInfo.service;
+
+import com.potato.balbambalbam.main.cardInfo.dto.VoiceRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client
+
+/**
+ * 인공지능서버와 통신하여 생성된 음성을 받아옴
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AiCardInfoService {
+
+    public void getTtsVoice(VoiceRequestDto voiceRequestDto) {
+
+    }
+}

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/service/AiCardInfoService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/service/AiCardInfoService.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 
@@ -22,11 +23,11 @@ public class AiCardInfoService {
         String wavFile = webClient.post()
                 .uri(TEMPORARY_URI)
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(voiceRequestDto, VoiceRequestDto.class)
+                .body(Mono.just(voiceRequestDto), VoiceRequestDto.class)
                 .retrieve()//요청
                 .bodyToMono(String.class)
                 .timeout(Duration.ofSeconds(2)) //2초 안에 응답 오지 않으면 TimeoutException 발생
-                .onErrorReturn("TimeoutException")    //에러 대신 -1 return
+                .onErrorReturn("TimeoutException")    //에러 대신 TimeoutException return
                 .block();
 
         return wavFile;

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/service/AiCardInfoService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/service/AiCardInfoService.java
@@ -5,11 +5,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
-import java.util.concurrent.TimeoutException;
 
 /**
  * 인공지능서버와 통신하여 생성된 음성을 받아옴

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/service/AiCardInfoService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/service/AiCardInfoService.java
@@ -3,8 +3,10 @@ package com.potato.balbambalbam.main.cardInfo.service;
 import com.potato.balbambalbam.main.cardInfo.dto.VoiceRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * 인공지능서버와 통신하여 생성된 음성을 받아옴
@@ -13,8 +15,17 @@ import org.springframework.web.reactive.function.client
 @RequiredArgsConstructor
 @Slf4j
 public class AiCardInfoService {
+    public static final String TEMPORARY_URI = "/아직안정해짐";
+    WebClient webClient = WebClient.builder().build();
+    public MultipartFile getTtsVoice(VoiceRequestDto voiceRequestDto) {
+        MultipartFile wavFile = webClient.post()
+                .uri(TEMPORARY_URI)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(voiceRequestDto, VoiceRequestDto.class)
+                .retrieve()//요청
+                .bodyToMono(MultipartFile.class)
+                .block();
 
-    public void getTtsVoice(VoiceRequestDto voiceRequestDto) {
-
+        return wavFile;
     }
 }

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/service/AiCardInfoService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/service/AiCardInfoService.java
@@ -8,6 +8,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+
 /**
  * 인공지능서버와 통신하여 생성된 음성을 받아옴
  */
@@ -24,6 +27,8 @@ public class AiCardInfoService {
                 .body(voiceRequestDto, VoiceRequestDto.class)
                 .retrieve()//요청
                 .bodyToMono(String.class)
+                .timeout(Duration.ofSeconds(2)) //2초 안에 응답 오지 않으면 TimeoutException 발생
+                .onErrorReturn("TimeoutException")    //에러 대신 -1 return
                 .block();
 
         return wavFile;

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoService.java
@@ -1,0 +1,44 @@
+package com.potato.balbambalbam.main.cardInfo.service;
+
+import com.potato.balbambalbam.entity.Card;
+import com.potato.balbambalbam.entity.User;
+import com.potato.balbambalbam.main.cardInfo.dto.VoiceRequestDto;
+import com.potato.balbambalbam.main.cardInfo.exception.UserNotFoundException;
+import com.potato.balbambalbam.main.cardList.exception.CardNotFoundException;
+import com.potato.balbambalbam.main.repository.CardRepository;
+import com.potato.balbambalbam.main.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CardInfoService {
+
+    private final UserRepository userRepository;
+    private final CardRepository cardRepository;
+    private final AiCardInfoService aiCardInfoService;
+
+    public String getCardInfo(Long cardId, Long userId){
+        //음성 생성
+        VoiceRequestDto voiceRequestDto = getUserInfo(userId);
+
+
+        //카드 정보 생성
+        Card card = cardRepository.findById(cardId).orElseThrow(() -> new CardNotFoundException("잘못된 URL 요청입니다"));
+        String text = card.getText();
+        String pronunciation = card.getPronunciation();
+
+        return null;
+    }
+
+    protected VoiceRequestDto getUserInfo(Long userId){
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("사용자가 존재하지 않습니다"));
+        Integer age = user.getAge();
+        Integer gender = user.getGender();
+
+        return new VoiceRequestDto(age, gender);
+    }
+
+}

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoService.java
@@ -28,8 +28,7 @@ public class CardInfoService {
     public CardInfoResponseDto getCardInfo(Long cardId, Long userId) {
         //음성 생성
 //        VoiceRequestDto voiceRequestDto = getUserInfo(userId);
-//        MultipartFile ttsVoice = aiCardInfoService.getTtsVoice(voiceRequestDto);
-//        String wavToString = convertWavToString(ttsVoice);
+//        String wavToString = aiCardInfoService.getTtsVoice(voiceRequestDto);
         String wavToString = "테스트입니다";
 
         //카드 정보 생성
@@ -43,20 +42,6 @@ public class CardInfoService {
         Integer gender = user.getGender();
 
         return new VoiceRequestDto(age, gender);
-    }
-
-    protected String convertWavToString(MultipartFile ttsVoice) {
-
-        try{
-            byte[] voiceBytes = ttsVoice.getBytes();
-            String voiceString = Base64.getEncoder().encodeToString(voiceBytes);
-
-            return voiceString;
-        }catch (IOException ex){
-            ex.printStackTrace();
-        }
-
-        return null;
     }
 
 }

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoService.java
@@ -4,6 +4,7 @@ import com.potato.balbambalbam.entity.Card;
 import com.potato.balbambalbam.entity.User;
 import com.potato.balbambalbam.main.cardInfo.dto.CardInfoResponseDto;
 import com.potato.balbambalbam.main.cardInfo.dto.VoiceRequestDto;
+import com.potato.balbambalbam.main.cardInfo.exception.AiConnectionException;
 import com.potato.balbambalbam.main.cardInfo.exception.UserNotFoundException;
 import com.potato.balbambalbam.main.cardList.exception.CardNotFoundException;
 import com.potato.balbambalbam.main.repository.CardBookmarkRepository;
@@ -25,12 +26,12 @@ public class CardInfoService {
 
     public CardInfoResponseDto getCardInfo(Long cardId, Long userId) {
         //음성 생성
-//        VoiceRequestDto voiceRequestDto = getUserInfo(userId);
-//        String wavToString = aiCardInfoService.getTtsVoice(voiceRequestDto);
-//        if(wavToString.equals("TimeoutException")){
-//            throw new AiConnectionException("음성 생성에 실패하였습니다");
-//        }
-        String wavToString = "테스트입니다";
+        VoiceRequestDto voiceRequestDto = getUserInfo(userId);
+        String wavToString = aiCardInfoService.getTtsVoice(voiceRequestDto);
+        if(wavToString.equals("TimeoutException")){
+            throw new AiConnectionException("음성 생성에 실패하였습니다");
+        }
+//        String wavToString = "테스트입니다";
 
         //카드 정보 생성
         Card card = cardRepository.findById(cardId).orElseThrow(() -> new CardNotFoundException("잘못된 URL 요청입니다"));

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoService.java
@@ -27,9 +27,10 @@ public class CardInfoService {
 
     public CardInfoResponseDto getCardInfo(Long cardId, Long userId) {
         //음성 생성
-        VoiceRequestDto voiceRequestDto = getUserInfo(userId);
-        MultipartFile ttsVoice = aiCardInfoService.getTtsVoice(voiceRequestDto);
-        String wavToString = convertWavToString(ttsVoice);
+//        VoiceRequestDto voiceRequestDto = getUserInfo(userId);
+//        MultipartFile ttsVoice = aiCardInfoService.getTtsVoice(voiceRequestDto);
+//        String wavToString = convertWavToString(ttsVoice);
+        String wavToString = "테스트입니다";
 
         //카드 정보 생성
         Card card = cardRepository.findById(cardId).orElseThrow(() -> new CardNotFoundException("잘못된 URL 요청입니다"));

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoService.java
@@ -4,7 +4,6 @@ import com.potato.balbambalbam.entity.Card;
 import com.potato.balbambalbam.entity.User;
 import com.potato.balbambalbam.main.cardInfo.dto.CardInfoResponseDto;
 import com.potato.balbambalbam.main.cardInfo.dto.VoiceRequestDto;
-import com.potato.balbambalbam.main.cardInfo.exception.AiConnectionException;
 import com.potato.balbambalbam.main.cardInfo.exception.UserNotFoundException;
 import com.potato.balbambalbam.main.cardList.exception.CardNotFoundException;
 import com.potato.balbambalbam.main.repository.CardBookmarkRepository;

--- a/src/main/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoService.java
@@ -4,17 +4,15 @@ import com.potato.balbambalbam.entity.Card;
 import com.potato.balbambalbam.entity.User;
 import com.potato.balbambalbam.main.cardInfo.dto.CardInfoResponseDto;
 import com.potato.balbambalbam.main.cardInfo.dto.VoiceRequestDto;
+import com.potato.balbambalbam.main.cardInfo.exception.AiConnectionException;
 import com.potato.balbambalbam.main.cardInfo.exception.UserNotFoundException;
 import com.potato.balbambalbam.main.cardList.exception.CardNotFoundException;
+import com.potato.balbambalbam.main.repository.CardBookmarkRepository;
 import com.potato.balbambalbam.main.repository.CardRepository;
 import com.potato.balbambalbam.main.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.util.Base64;
 
 @Service
 @RequiredArgsConstructor
@@ -23,17 +21,22 @@ public class CardInfoService {
 
     private final UserRepository userRepository;
     private final CardRepository cardRepository;
+    private final CardBookmarkRepository cardBookmarkRepository;
     private final AiCardInfoService aiCardInfoService;
 
     public CardInfoResponseDto getCardInfo(Long cardId, Long userId) {
         //음성 생성
 //        VoiceRequestDto voiceRequestDto = getUserInfo(userId);
 //        String wavToString = aiCardInfoService.getTtsVoice(voiceRequestDto);
+//        if(wavToString.equals("TimeoutException")){
+//            throw new AiConnectionException("음성 생성에 실패하였습니다");
+//        }
         String wavToString = "테스트입니다";
 
         //카드 정보 생성
         Card card = cardRepository.findById(cardId).orElseThrow(() -> new CardNotFoundException("잘못된 URL 요청입니다"));
-        return new CardInfoResponseDto(cardId, card.getText(), card.getPronunciation(), wavToString);
+        boolean isBookmark = cardBookmarkRepository.existsByCardIdAndUserId(cardId, userId);
+        return new CardInfoResponseDto(cardId, card.getText(), card.getPronunciation(), isBookmark, wavToString);
     }
 
     protected VoiceRequestDto getUserInfo(Long userId){

--- a/src/main/java/com/potato/balbambalbam/main/cardList/controller/CardListController.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/controller/CardListController.java
@@ -15,7 +15,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.nio.charset.Charset;
 import java.util.List;

--- a/src/main/java/com/potato/balbambalbam/main/cardList/controller/CardListController.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/controller/CardListController.java
@@ -1,10 +1,10 @@
-package com.potato.balbambalbam.main.controller;
+package com.potato.balbambalbam.main.cardList.controller;
 
-import com.potato.balbambalbam.main.dto.CardListResponse;
-import com.potato.balbambalbam.main.dto.ExceptionDto;
-import com.potato.balbambalbam.main.dto.ResponseCardDto;
-import com.potato.balbambalbam.main.service.CardListService;
-import com.potato.balbambalbam.main.service.UpdatePhonemeService;
+import com.potato.balbambalbam.main.cardList.dto.CardListResponse;
+import com.potato.balbambalbam.main.cardList.dto.ExceptionDto;
+import com.potato.balbambalbam.main.cardList.dto.ResponseCardDto;
+import com.potato.balbambalbam.main.cardList.service.CardListService;
+import com.potato.balbambalbam.main.cardList.service.UpdatePhonemeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/potato/balbambalbam/main/cardList/controller/CardListController.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/controller/CardListController.java
@@ -24,6 +24,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "CardList", description = "CardList API")
 public class CardListController {
+    //TODO : user 동적으로 할당
     public static final long TEMPORARY_USER_ID = 1L;
     private final CardListService cardListService;
     private final UpdatePhonemeService updatePhonemeService;

--- a/src/main/java/com/potato/balbambalbam/main/cardList/dto/CardListResponse.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/dto/CardListResponse.java
@@ -1,4 +1,4 @@
-package com.potato.balbambalbam.main.dto;
+package com.potato.balbambalbam.main.cardList.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;

--- a/src/main/java/com/potato/balbambalbam/main/cardList/dto/ExceptionDto.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/dto/ExceptionDto.java
@@ -1,4 +1,4 @@
-package com.potato.balbambalbam.main.dto;
+package com.potato.balbambalbam.main.cardList.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;

--- a/src/main/java/com/potato/balbambalbam/main/cardList/dto/MainExceptionResolverController.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/dto/MainExceptionResolverController.java
@@ -1,4 +1,4 @@
-package com.potato.balbambalbam.main.dto;
+package com.potato.balbambalbam.main.cardList.dto;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/potato/balbambalbam/main/cardList/dto/ResponseCardDto.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/dto/ResponseCardDto.java
@@ -1,4 +1,4 @@
-package com.potato.balbambalbam.main.dto;
+package com.potato.balbambalbam.main.cardList.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;

--- a/src/main/java/com/potato/balbambalbam/main/cardList/exception/CardNotFoundException.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/exception/CardNotFoundException.java
@@ -1,9 +1,5 @@
 package com.potato.balbambalbam.main.cardList.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "잘못된 요청입니다.")
 public class CardNotFoundException extends IllegalArgumentException{
     public CardNotFoundException(String s) {
         super(s);

--- a/src/main/java/com/potato/balbambalbam/main/cardList/exception/CardNotFoundException.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/exception/CardNotFoundException.java
@@ -1,4 +1,4 @@
-package com.potato.balbambalbam.main.exception;
+package com.potato.balbambalbam.main.cardList.exception;
 
 public class CardNotFoundException extends IllegalArgumentException{
     public CardNotFoundException(String s) {

--- a/src/main/java/com/potato/balbambalbam/main/cardList/exception/CardNotFoundException.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/exception/CardNotFoundException.java
@@ -1,5 +1,9 @@
 package com.potato.balbambalbam.main.cardList.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "잘못된 요청입니다.")
 public class CardNotFoundException extends IllegalArgumentException{
     public CardNotFoundException(String s) {
         super(s);

--- a/src/main/java/com/potato/balbambalbam/main/cardList/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/exception/CategoryNotFoundException.java
@@ -1,4 +1,4 @@
-package com.potato.balbambalbam.main.exception;
+package com.potato.balbambalbam.main.cardList.exception;
 
 public class CategoryNotFoundException extends IllegalArgumentException{
     public CategoryNotFoundException(String message) {

--- a/src/main/java/com/potato/balbambalbam/main/cardList/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/exception/CategoryNotFoundException.java
@@ -1,5 +1,9 @@
 package com.potato.balbambalbam.main.cardList.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "잘못된 요청입니다.")
 public class CategoryNotFoundException extends IllegalArgumentException{
     public CategoryNotFoundException(String message) {
         super(message);

--- a/src/main/java/com/potato/balbambalbam/main/cardList/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/exception/CategoryNotFoundException.java
@@ -1,9 +1,5 @@
 package com.potato.balbambalbam.main.cardList.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "잘못된 요청입니다.")
 public class CategoryNotFoundException extends IllegalArgumentException{
     public CategoryNotFoundException(String message) {
         super(message);

--- a/src/main/java/com/potato/balbambalbam/main/cardList/service/CardListService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/service/CardListService.java
@@ -1,16 +1,18 @@
-package com.potato.balbambalbam.main.service;
+package com.potato.balbambalbam.main.cardList.service;
 
-import com.potato.balbambalbam.entity.*;
-import com.potato.balbambalbam.main.dto.ResponseCardDto;
-import com.potato.balbambalbam.main.exception.CardNotFoundException;
-import com.potato.balbambalbam.main.exception.CategoryNotFoundException;
+import com.potato.balbambalbam.entity.Card;
+import com.potato.balbambalbam.entity.CardBookmark;
+import com.potato.balbambalbam.entity.CardScore;
+import com.potato.balbambalbam.entity.Category;
+import com.potato.balbambalbam.main.cardList.dto.ResponseCardDto;
+import com.potato.balbambalbam.main.cardList.exception.CardNotFoundException;
+import com.potato.balbambalbam.main.cardList.exception.CategoryNotFoundException;
 import com.potato.balbambalbam.main.repository.*;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Service

--- a/src/main/java/com/potato/balbambalbam/main/cardList/service/UpdatePhonemeService.java
+++ b/src/main/java/com/potato/balbambalbam/main/cardList/service/UpdatePhonemeService.java
@@ -1,4 +1,4 @@
-package com.potato.balbambalbam.main.service;
+package com.potato.balbambalbam.main.cardList.service;
 
 import com.potato.balbambalbam.entity.Card;
 import com.potato.balbambalbam.entity.Phoneme;

--- a/src/main/java/com/potato/balbambalbam/main/repository/UserRepository.java
+++ b/src/main/java/com/potato/balbambalbam/main/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.potato.balbambalbam.main.repository;
+
+import com.potato.balbambalbam.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Override
+    Optional<User> findById(Long aLong);
+}

--- a/src/test/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoServiceTest.java
+++ b/src/test/java/com/potato/balbambalbam/main/cardInfo/service/CardInfoServiceTest.java
@@ -1,0 +1,56 @@
+package com.potato.balbambalbam.main.cardInfo.service;
+
+import com.potato.balbambalbam.main.cardInfo.dto.CardInfoResponseDto;
+import com.potato.balbambalbam.main.cardInfo.dto.VoiceRequestDto;
+import com.potato.balbambalbam.main.cardInfo.exception.UserNotFoundException;
+import com.potato.balbambalbam.main.cardList.exception.CardNotFoundException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+class CardInfoServiceTest {
+
+    @Autowired
+    CardInfoService cardInfoService;
+    @Test
+    void getCardInfoTest(){
+        //given
+        Long userId = 1L;
+        Long cardId = 194L; //수달
+
+        //when
+        CardInfoResponseDto cardInfo = cardInfoService.getCardInfo(cardId, userId);
+
+        //then
+        assertThat(cardInfo.getText()).isEqualTo("수달");
+        assertThat(cardInfo.getPronunciation()).isEqualTo("수달");
+    }
+
+    @Test
+    void getCardInfoErrorTest(){
+        //given
+        Long userId = 1L;
+        Long errorCardId = 12345L; //수달
+
+        //when then
+        org.junit.jupiter.api.Assertions.assertThrows(CardNotFoundException.class, ()-> cardInfoService.getCardInfo(errorCardId, userId));
+    }
+
+    @Test
+    void getUserInfoTest(){
+        //given
+        Long userId = 1L;
+        Long userIdError = 12345L;
+
+        //when
+        VoiceRequestDto userInfo = cardInfoService.getUserInfo(userId);
+
+        //then
+        assertThat(userInfo.getGender()).isEqualTo(0);
+        org.junit.jupiter.api.Assertions.assertThrows(UserNotFoundException.class, () -> cardInfoService.getUserInfo(userIdError));
+    }
+}

--- a/src/test/java/com/potato/balbambalbam/main/cardList/service/CardListServiceTest.java
+++ b/src/test/java/com/potato/balbambalbam/main/cardList/service/CardListServiceTest.java
@@ -1,4 +1,4 @@
-package com.potato.balbambalbam.main.service;
+package com.potato.balbambalbam.main.cardList.service;
 
 import com.potato.balbambalbam.main.cardList.service.CardListService;
 import com.potato.balbambalbam.main.cardList.dto.ResponseCardDto;

--- a/src/test/java/com/potato/balbambalbam/main/cardList/service/PhonemeServiceTest.java
+++ b/src/test/java/com/potato/balbambalbam/main/cardList/service/PhonemeServiceTest.java
@@ -1,4 +1,4 @@
-package com.potato.balbambalbam.main.service;
+package com.potato.balbambalbam.main.cardList.service;
 
 import com.potato.balbambalbam.main.cardList.service.UpdatePhonemeService;
 import org.assertj.core.api.Assertions;

--- a/src/test/java/com/potato/balbambalbam/main/service/CardListServiceTest.java
+++ b/src/test/java/com/potato/balbambalbam/main/service/CardListServiceTest.java
@@ -1,8 +1,7 @@
 package com.potato.balbambalbam.main.service;
 
-import com.potato.balbambalbam.entity.Card;
-import com.potato.balbambalbam.main.dto.ResponseCardDto;
-import org.assertj.core.api.Assertions;
+import com.potato.balbambalbam.main.cardList.service.CardListService;
+import com.potato.balbambalbam.main.cardList.dto.ResponseCardDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/potato/balbambalbam/main/service/PhonemeServiceTest.java
+++ b/src/test/java/com/potato/balbambalbam/main/service/PhonemeServiceTest.java
@@ -1,5 +1,6 @@
 package com.potato.balbambalbam.main.service;
 
+import com.potato.balbambalbam.main.cardList.service.UpdatePhonemeService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## Description
#### card info
- 원하는 카드 정보를 프론트로 제공해주는 로직을 구현했습니다.
- 앱에서 카드정보 요청시 인공지능 서버로 사용자 맞춤 음성 생성을 요청하는 로직을 구현했습니다.

#### 에러 처리 logic 추가
- MainExceptionResolverController의 에러 처리 로직에서 중복을 없애고 HTTP status마다 한 method로 에러를 처리할 수 있도록 했습니다.

#### ETC
- directory 변화가 있었습니다. MainExceptionResolverController를 /main/cardList/dto에서 / main으로 이동하였고, main directroy는 /main/cardInfo, /main/cardList, /main/repository로 구성하였습니다.
![image](https://github.com/Capstone-4Potato/backend-server/assets/108220648/e96659d5-b939-4a5b-bf9f-9d5abb5e9c8c)
- springReact를 사용하기 위해 dependency 추가 했습니다
![image](https://github.com/Capstone-4Potato/backend-server/assets/108220648/5a63c69e-7c72-415f-91f9-0c981a90dfc3)


## To Reviewers
- 확인 부탁드립니다.