### PR TITLE
탈퇴한 회원 로직 구현

### DIFF
--- a/src/main/java/com/potato/balbambalbam/card/cardFeedback/controller/CardFeedbackController.java
+++ b/src/main/java/com/potato/balbambalbam/card/cardFeedback/controller/CardFeedbackController.java
@@ -46,7 +46,7 @@ public class CardFeedbackController {
                                                    @RequestHeader("access") String access,
                                                    @Validated @RequestBody UserFeedbackRequestDto userFeedbackRequestDto) {
 
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
 
         UserFeedbackResponseDto userFeedbackResponseDto = cardFeedbackService.postUserFeedback(userFeedbackRequestDto, userId, cardId);
         userLevelService.updateUserLevelInfo(cardId, userId, userFeedbackResponseDto.getUserScore());
@@ -66,7 +66,7 @@ public class CardFeedbackController {
     public ResponseEntity<Object> postCustomUserFeedback(@PathVariable("cardId") Long cardId,
                                                    @Validated @RequestBody UserFeedbackRequestDto userFeedbackRequestDto,
                                                          @RequestHeader("access") String access)  {
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
 
         UserFeedbackResponseDto userFeedbackResponseDto = customCardFeedbackService.postUserFeedback(userFeedbackRequestDto, cardId, userId);
         userLevelService.updateCustomCardUserLevelInfo(cardId, userId, userFeedbackResponseDto.getUserScore());
@@ -86,7 +86,7 @@ public class CardFeedbackController {
     public ResponseEntity<Object> postTodayCardUserFeedback(@PathVariable("cardId") Long cardId,
                                                          @Validated @RequestBody UserFeedbackRequestDto userFeedbackRequestDto,
                                                          @RequestHeader("access") String access)  {
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
 
         UserFeedbackResponseDto userFeedbackResponseDto = todayCardFeedbackService.postUserFeedback(userFeedbackRequestDto, cardId, userId);
         userLevelService.updateCustomCardUserLevelInfo(cardId, userId, userFeedbackResponseDto.getUserScore());

--- a/src/main/java/com/potato/balbambalbam/card/cardInfo/controller/CardInfoController.java
+++ b/src/main/java/com/potato/balbambalbam/card/cardInfo/controller/CardInfoController.java
@@ -42,7 +42,7 @@ public class CardInfoController {
             }
     )
     public ResponseEntity<CardInfoResponseDto> getCardInfo(@PathVariable("cardId") Long cardId, @RequestHeader("access") String access) {
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
         CardInfoResponseDto cardInfoResponseDto = cardInfoService.getCardInfo(userId, cardId);
         return ResponseEntity.ok().body(cardInfoResponseDto);
     }
@@ -56,7 +56,7 @@ public class CardInfoController {
             }
     )
     public ResponseEntity<CardInfoResponseDto> postCustomCardInfo(@PathVariable("cardId") Long cardId, @RequestHeader("access") String access) {
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
         CardInfoResponseDto cardInfoResponseDto = customCardInfoService.getCustomCardInfo(userId, cardId);
 
         return ResponseEntity.ok().body(cardInfoResponseDto);
@@ -71,7 +71,7 @@ public class CardInfoController {
             }
     )
     public ResponseEntity<TodayCardInfoResponseDto> postTodayCardInfo(@PathVariable("cardId") Long cardId, @RequestHeader("access") String access) {
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
         TodayCardInfoResponseDto cardInfoResponseDto = todayCardInfoService.getTodayCardInfo(userId, cardId);
 
         return ResponseEntity.ok().body(cardInfoResponseDto);

--- a/src/main/java/com/potato/balbambalbam/card/todayCourse/controller/TodayCourseController.java
+++ b/src/main/java/com/potato/balbambalbam/card/todayCourse/controller/TodayCourseController.java
@@ -37,7 +37,7 @@ public class TodayCourseController {
     })
     public ResponseEntity<TodayCourseResponseDto> getCardList(@RequestBody TodayCourseRequestDto requestDto,
                                                               @RequestHeader("access") String access) {
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
 
         TodayCourseResponseDto response = todayCourseService.getCardList(userId, requestDto);
 

--- a/src/main/java/com/potato/balbambalbam/home/customCard/controller/CustomCardController.java
+++ b/src/main/java/com/potato/balbambalbam/home/customCard/controller/CustomCardController.java
@@ -33,7 +33,7 @@ public class CustomCardController {
             @ApiResponse(responseCode = "400", description = "ERROR : 카드를 생성 불가(10개 이상 or 한국어 X, 35자 이상)", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
     })
     public ResponseEntity<CustomCardResponseDto> postCustomCard(@Validated @RequestBody CustomCardRequestDto customCardRequestDto, @RequestHeader("access") String access) {
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
 
         CustomCardResponseDto customCardResponse = customCardService.createCustomCardIfPossible(customCardRequestDto.getText(), userId);
 
@@ -47,7 +47,7 @@ public class CustomCardController {
             @ApiResponse(responseCode = "400", description = "ERROR : 카드 삭제 불가", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
     })
     public ResponseEntity deleteCustomCard(@PathVariable("cardId") Long cardId, @RequestHeader("access") String access) throws CardDeleteException {
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
 
         boolean isDeleted = customCardService.deleteCustomCard(userId, cardId);
 

--- a/src/main/java/com/potato/balbambalbam/home/customCard/controller/CustomCardListController.java
+++ b/src/main/java/com/potato/balbambalbam/home/customCard/controller/CustomCardListController.java
@@ -38,7 +38,7 @@ public class CustomCardListController {
             @ApiResponse(responseCode = "400", description = "ERROR : 존재하지 않는 카테고리 조회", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
     })
     public ResponseEntity<CardListResponseDto<List<CustomCardDto>>> getCustomCardList(@RequestHeader("access") String access) {
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
 
         List<CustomCardDto> cardDtoList = cardListService.getCustomCards(userId);
         CardListResponseDto<List<CustomCardDto>> response = new CardListResponseDto<>(cardDtoList, cardDtoList.size());

--- a/src/main/java/com/potato/balbambalbam/home/learningCourse/controller/CardListController.java
+++ b/src/main/java/com/potato/balbambalbam/home/learningCourse/controller/CardListController.java
@@ -37,7 +37,7 @@ public class CardListController {
     })
     public ResponseEntity<CardListResponseDto<List<ResponseCardDto>>> getCardList(@RequestParam("level") Long level,
                                                                                   @RequestHeader("access") String access){
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
 
         List<ResponseCardDto> cardDtoList = cardListService.getCardsByCategory(level, userId);
         CardListResponseDto<List<ResponseCardDto>> response = new CardListResponseDto<>(cardDtoList, cardDtoList.size());
@@ -53,7 +53,7 @@ public class CardListController {
             @ApiResponse(responseCode = "400", description = "ERROR : 조회 실패", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
     })
     public ResponseEntity<CourseResponseDto> getCourseList(@RequestHeader("access") String access){
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
 
         CourseResponseDto response = cardListService.getCourseList(userId);
 
@@ -68,7 +68,7 @@ public class CardListController {
             @ApiResponse(responseCode = "400", description = "ERROR : 존재하지 않는 카드", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
     })
     public ResponseEntity updateCardBookmark(@PathVariable("cardId") Integer cardId, @RequestHeader("access") String access){
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
 
         String message = cardListService.toggleCardBookmark(Long.valueOf(cardId), userId);
         return ResponseEntity.ok().body(message);

--- a/src/main/java/com/potato/balbambalbam/home/menu/controller/BookmarkCardsController.java
+++ b/src/main/java/com/potato/balbambalbam/home/menu/controller/BookmarkCardsController.java
@@ -34,7 +34,7 @@ public class BookmarkCardsController {
             @ApiResponse(responseCode = "400", description = "ERROR : 존재하지 않는 카테고리 조회", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
     })
     public ResponseEntity<BookmarkCardResponseDto> getCardList(@RequestHeader("access") String access) {
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
 
         BookmarkCardResponseDto responseDto = bookmarkCardsService.getCards(userId);
         return ResponseEntity.ok().body(responseDto);

--- a/src/main/java/com/potato/balbambalbam/home/menu/controller/MissedCardsController.java
+++ b/src/main/java/com/potato/balbambalbam/home/menu/controller/MissedCardsController.java
@@ -34,7 +34,7 @@ public class MissedCardsController {
             @ApiResponse(responseCode = "400", description = "ERROR : 존재하지 않는 카테고리 조회", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
     })
     public ResponseEntity<MissedCardResponseDto> getCardList(@RequestHeader("access") String access) {
-        Long userId = joinService.findUserBySocialId(jwtUtil.getSocialId(access)).getId();
+        Long userId = jwtUtil.getUserId(access);
 
         MissedCardResponseDto responseDto = missedCardsService.getCards(userId);
 

--- a/src/main/java/com/potato/balbambalbam/myReport/report/controller/ReportController.java
+++ b/src/main/java/com/potato/balbambalbam/myReport/report/controller/ReportController.java
@@ -25,11 +25,6 @@ public class ReportController {
     private final JWTUtil jwtUtil;
     private final ReportInfoService reportInfoService;
 
-    private Long extractUserIdFromToken(String access) { // access 토큰으로부터 userId 추출하는 함수
-        String socialId = jwtUtil.getSocialId(access);
-        return joinService.findUserBySocialId(socialId).getId();
-    }
-
     @Operation(summary = "My report 화면 정보 조회", description = "My report 화면에 필요한 모든 정보를 반환한다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "My report 화면 정보 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReportInfoDto.class))),
@@ -37,7 +32,7 @@ public class ReportController {
     })
     @GetMapping("/report")
     public ResponseEntity<ReportInfoDto> getHomeInfo(@RequestHeader("access") String access) {
-        Long userId = extractUserIdFromToken(access);
+        Long userId = jwtUtil.getUserId(access);
         ReportInfoDto response = reportInfoService.getMyReportInfo(userId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/potato/balbambalbam/myReport/test/controller/WeakSoundTestController.java
+++ b/src/main/java/com/potato/balbambalbam/myReport/test/controller/WeakSoundTestController.java
@@ -37,18 +37,13 @@ public class WeakSoundTestController {
     private final JWTUtil jwtUtil;
     private final WeakSoundTestService weakSoundTestService;
 
-    private Long extractUserIdFromToken(String access) {
-        String socialId = jwtUtil.getSocialId(access);
-        return joinService.findUserBySocialId(socialId).getId();
-    }
-
     @Operation(summary = "취약음소 테스트 존재 여부 확인", description = "이전에 진행중이던 테스트가 있는지 확인한다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "확인 완료", content = @Content(mediaType = "application/json", schema = @Schema(implementation = TestStartResponseDto.class)))
     })
     @GetMapping("/test/check")
     public ResponseEntity<TestStartResponseDto> checkTest(@RequestHeader("access") String access) {
-        Long userId = extractUserIdFromToken(access);
+        Long userId = jwtUtil.getUserId(access);
         TestStartResponseDto response = weakSoundTestService.checkTestStatus(userId);
         return ResponseEntity.ok(response);
     }
@@ -59,7 +54,7 @@ public class WeakSoundTestController {
     })
     @PostMapping("/test/new")
     public ResponseEntity<List<WeakSoundTestListDto>> startNewTest(@RequestHeader("access") String access) {
-        Long userId = extractUserIdFromToken(access);
+        Long userId = jwtUtil.getUserId(access);
         weakSoundTestService.startNewTest(userId);
         return ResponseEntity.ok(weakSoundTestService.getAllTests());
     }
@@ -71,7 +66,7 @@ public class WeakSoundTestController {
     })
     @GetMapping("/test/continue")
     public ResponseEntity<List<WeakSoundTestListDto>> continueTest(@RequestHeader("access") String access) {
-        Long userId = extractUserIdFromToken(access);
+        Long userId = jwtUtil.getUserId(access);
         List<WeakSoundTestListDto> remainingTests = weakSoundTestService.getContinueTests(userId);
         return ResponseEntity.ok(remainingTests);
     }
@@ -85,7 +80,7 @@ public class WeakSoundTestController {
     })
     @PostMapping(value = "/test/{cardId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<String> uploadFile(@PathVariable("cardId") Long id, @RequestHeader("access") String access, @RequestParam("userAudio") MultipartFile userAudio) throws IOException {
-        Long userId = extractUserIdFromToken(access);
+        Long userId = jwtUtil.getUserId(access);
 
         if (userAudio.isEmpty()) {
             throw new ParameterNotFoundException("사용자 음성 파일이 비었습니다.");
@@ -106,7 +101,7 @@ public class WeakSoundTestController {
     })
     @PostMapping("/test/finalize")
     public ResponseEntity<Map<Long, Integer>> finalizeAnalysis(@RequestHeader("access") String access) {
-        Long userId = extractUserIdFromToken(access);
+        Long userId = jwtUtil.getUserId(access);
         Map<Long, Integer> topPhonemes = weakSoundTestService.getTopPhonemes(userId);
         weakSoundTestService.finalizeTestStatus(userId);
         return ResponseEntity.ok(topPhonemes);

--- a/src/main/java/com/potato/balbambalbam/myReport/weaksound/controller/PhonemeController.java
+++ b/src/main/java/com/potato/balbambalbam/myReport/weaksound/controller/PhonemeController.java
@@ -36,10 +36,6 @@ public class PhonemeController {
     private final PhonemeService phonemeService;
     private final PhonemeRepository phonemeRepository;
 
-    private Long extractUserIdFromToken(String access) {
-        String socialId = jwtUtil.getSocialId(access);
-        return joinService.findUserBySocialId(socialId).getId();
-    }
 
     @Operation(summary = "사용자의 취약음소 제공", description = "사용자의 취약음소 4개를 제공한다.")
     @ApiResponses(value = {
@@ -49,7 +45,7 @@ public class PhonemeController {
     })
     @GetMapping("/test/phonemes")
     public ResponseEntity<List<UserWeakSoundResponseDto>> getWeakPhonemesByUserId(@RequestHeader("access") String access) {
-        Long userId = extractUserIdFromToken(access);
+        Long userId = jwtUtil.getUserId(access);
         List<UserWeakSoundResponseDto> weakPhonemes = phonemeService.getWeakPhonemes(userId);
         if (weakPhonemes.isEmpty()) {
             throw new ResponseNotFoundException("취약음소가 없습니다.");
@@ -64,7 +60,7 @@ public class PhonemeController {
     })
     @GetMapping("/test/all")
     public ResponseEntity<List<PhonemeResponseDto>> getAllPhonemesWithWeakStatus(@RequestHeader("access") String access) {
-        Long userId = extractUserIdFromToken(access);
+        Long userId = jwtUtil.getUserId(access);
         return ResponseEntity.ok(phonemeService.getAllPhonemes(userId));
     }
 
@@ -75,7 +71,7 @@ public class PhonemeController {
     })
     @PostMapping("/test/add")
     public ResponseEntity<?> addWeakPhonemes(@RequestHeader("access") String access, @RequestBody List<Long> phonemeIds) {
-        Long userId = extractUserIdFromToken(access);
+        Long userId = jwtUtil.getUserId(access);
         phonemeService.addWeakPhonemes(userId, phonemeIds);
         return ResponseEntity.ok("취약음소가 추가되었습니다.");
     }
@@ -87,7 +83,7 @@ public class PhonemeController {
     })
     @DeleteMapping("test/phonemes/{phonemeId}")
     public ResponseEntity<?> deleteWeakPhoneme(@RequestHeader("access") String access, @PathVariable Long phonemeId) {
-        Long userId = extractUserIdFromToken(access);
+        Long userId = jwtUtil.getUserId(access);
         phonemeService.deleteWeakPhoneme(userId, phonemeId);
         return ResponseEntity.ok("사용자의 취약음소가 삭제되었습니다.");
     }

--- a/src/main/java/com/potato/balbambalbam/user/home/controller/HomeController.java
+++ b/src/main/java/com/potato/balbambalbam/user/home/controller/HomeController.java
@@ -28,10 +28,6 @@ public class HomeController {
     private final HomeInfoService homeInfoService;
     private final NotificationService notificationService;
 
-    private Long extractUserIdFromToken(String access) { // access 토큰으로부터 userId 추출하는 함수
-        String socialId = jwtUtil.getSocialId(access);
-        return joinService.findUserBySocialId(socialId).getId();
-    }
 
     @Operation(summary = "홈 화면 정보 조회", description = "사용자의 홈 화면에 필요한 모든 정보를 반환한다.")
     @ApiResponses(value = {
@@ -40,7 +36,7 @@ public class HomeController {
     })
     @GetMapping("/home")
     public ResponseEntity<HomeInfoDto> getHomeInfo(@RequestHeader("access") String access) {
-        Long userId = extractUserIdFromToken(access);
+        Long userId = jwtUtil.getUserId(access);
         HomeInfoDto response = homeInfoService.getHomeInfo(userId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/potato/balbambalbam/user/join/service/JoinService.java
+++ b/src/main/java/com/potato/balbambalbam/user/join/service/JoinService.java
@@ -102,8 +102,8 @@ public class JoinService {
     }
 
     @Transactional
-    public String recoverDeletedUser(Long userId, HttpServletResponse response) {
-        User user = userRepository.findById(userId)
+    public String recoverDeletedUser(String  socialId, HttpServletResponse response) {
+        User user = userRepository.findBySocialId(socialId)
                 .orElseThrow(() -> new UserNotFoundException("해당 사용자를 찾을 수 없습니다."));
 
         if (user.getStatusId() != 3L) {

--- a/src/main/java/com/potato/balbambalbam/user/notification/controller/NotificationController.java
+++ b/src/main/java/com/potato/balbambalbam/user/notification/controller/NotificationController.java
@@ -28,11 +28,6 @@ public class NotificationController {
     private final JWTUtil jwtUtil;
     private final NotificationService notificationService;
 
-    private Long extractUserIdFromToken(String access) { // access 토큰으로부터 userId 추출하는 함수
-        String socialId = jwtUtil.getSocialId(access);
-        return joinService.findUserBySocialId(socialId).getId();
-    }
-
     @Operation(summary = "알림 목록 조회", description = "알림을 반환한다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "알림 반환 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NotificationDto.class))),
@@ -40,7 +35,7 @@ public class NotificationController {
     })
     @GetMapping("/notification")
     public ResponseEntity<List<NotificationDto>> getNotification(@RequestHeader("access") String access) {
-        Long userId = extractUserIdFromToken(access);
+        Long userId = jwtUtil.getUserId(access);
         List<NotificationDto> notifications = notificationService.getActiveNotifications(userId);
         return ResponseEntity.ok(notifications);
     }
@@ -52,7 +47,7 @@ public class NotificationController {
     })
     @PostMapping("/notification/{notificationId}")
     public ResponseEntity<Void> readNotification(@PathVariable Long notificationId, @RequestHeader("access") String access) {
-        Long userId = extractUserIdFromToken(access);
+        Long userId = jwtUtil.getUserId(access);
         notificationService.markAsRead(notificationId, userId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,13 +3,13 @@ spring.application.name=balbambalbam
 spring.servlet.multipart.max-file-size=3MB
 
 # prod
-#spring.profiles.active=prod
+spring.profiles.active=prod
 
 # local
 #spring.profiles.active=local
 
 #dev
-spring.profiles.active=dev
+#spring.profiles.active=dev
 
 # log level
 logging.level.root=info


### PR DESCRIPTION
- **복구를 선택한 경우**:
    - 클라이언트가 `/users/recover/{userId}`로 POST 요청.
    - 서버는 `recoverDeletedUser`를 실행해 `status_id`를 `ACTIVE(1)`로 변경하고 새 토큰을 발급.
- **복구 성공 응답**:
    - `access`, `refresh` 토큰을 응답 헤더에 추가.